### PR TITLE
Force using openssl 1.1 for ruby3.0.0

### DIFF
--- a/versions/3/0/0/derivation.nix
+++ b/versions/3/0/0/derivation.nix
@@ -1,1 +1,1 @@
-import ../derivation.nix
+meta: _pkgs: ((import ../derivation.nix meta) _pkgs).override { openssl = _pkgs.pkgs.openssl_1_1; }

--- a/versions/3/0/0/derivation.nix
+++ b/versions/3/0/0/derivation.nix
@@ -1,1 +1,1 @@
-meta: _pkgs: ((import ../derivation.nix meta) _pkgs).override { openssl = _pkgs.pkgs.openssl_1_1; }
+import ../derivation.nix


### PR DESCRIPTION
Ruby 3.0.0 doesn't work with the latest openssl version (tested on 3.0.7-dev).
Steps to reproduce:
Create a file devenv.nix:
```
{ pkgs, nixpkgs-ruby, ... }:

{
  languages.ruby.enable = true;
  languages.ruby.package = nixpkgs-ruby.lib.mkRuby { inherit pkgs; rubyVersion = "3.0.0"; };
}
```
Create a file devenv.yaml:
```
inputs:
  nixpkgs:
    url: github:NixOS/nixpkgs/nixpkgs-unstable
  nixpkgs-ruby:
    url: github:bobvanderlinden/nixpkgs-ruby
```
then call:
```
devenv update
devenv shell
```
I got the error:
```
In file included from ./ossl.h:156:
./openssl_missing.h:239:11: warning: 'TS_VERIFY_CTS_set_certs' macro redefined [-Wmacro-redefined]
#  define TS_VERIFY_CTS_set_certs(ctx, crts) ((ctx)->certs=(crts))
          ^
/nix/store/pq3rqbpmxby9v4qzwasgi4w6np3r3kxv-openssl-3.0.7-dev/include/openssl/ts.h:424:11: note: previous definition is here
#  define TS_VERIFY_CTS_set_certs(ctx, cert) TS_VERIFY_CTX_set_certs(ctx,cert)
ossl_pkey_rsa.c:950:5: error: use of undeclared identifier 'RSA_SSLV23_PADDING'
```

This PR should fix the error:
```
(devenv) RaspberryPi-home:magic dzam$ ruby -v
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin22]
(devenv) RaspberryPi-home:magic dzam$ which ruby
/nix/store/lv7fyqfjx03h6pylclxpsyydd3bvmxlv-devenv-profile/bin/ruby
(devenv) RaspberryPi-home:magic dzam$ openssl version
OpenSSL 1.1.1s  1 Nov 2022
(devenv) RaspberryPi-home:magic dzam$ which openssl
/nix/store/lv7fyqfjx03h6pylclxpsyydd3bvmxlv-devenv-profile/bin/openssl
```