### PR TITLE
Set open ssl for ruby 301

### DIFF
--- a/versions/3/0/1/derivation.nix
+++ b/versions/3/0/1/derivation.nix
@@ -1,1 +1,1 @@
-import ../derivation.nix
+meta: _pkgs: ((import ../derivation.nix meta) _pkgs).override { openssl = _pkgs.pkgs.openssl_1_1; }

--- a/versions/3/0/1/derivation.nix
+++ b/versions/3/0/1/derivation.nix
@@ -1,1 +1,1 @@
-meta: _pkgs: ((import ../derivation.nix meta) _pkgs).override { openssl = _pkgs.pkgs.openssl_1_1; }
+import ../derivation.nix

--- a/versions/3/0/5/meta.nix
+++ b/versions/3/0/5/meta.nix
@@ -6,6 +6,6 @@
     "5"
     ""
   ];
-  url = https://cache.ruby-lang.org/pub/ruby/ruby-3.0.5.tar.gz;
+  url = https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.5.tar.gz;
   sha256 = "9afc6380a027a4fe1ae1a3e2eccb6b497b9c5ac0631c12ca56f9b7beb4848776";
 }

--- a/versions/3/0/derivation.nix
+++ b/versions/3/0/derivation.nix
@@ -1,1 +1,1 @@
-import ../derivation.nix
+meta: _pkgs: ((import ../derivation.nix meta) _pkgs).override { openssl = _pkgs.pkgs.openssl_1_1; }


### PR DESCRIPTION
1. Set `openssl` version to 1.1 for ruby 3.0
2. Fix ruby 3.0.5 source path. This one doesn't work anymore https://cache.ruby-lang.org/pub/ruby/ruby-3.0.5.tar.gz;