### PR TITLE
Inline rubygems patch to fix sha mismatch

### DIFF
--- a/lib/rubygems/3.0.nix
+++ b/lib/rubygems/3.0.nix
@@ -10,12 +10,7 @@ stdenv.mkDerivation {
     url = "http://production.cf.rubygems.org/rubygems/rubygems-3.2.33.tgz";
     hash = "sha256-bIQIzS4F3IdwwxdmH0jVnNKcrLzRji8K7V1LqoibkC0=";
   };
-  patches = [
-    (fetchurl {
-      url = "https://github.com/bobvanderlinden/rubygems/commit/0b5bcc8075deaedf692ac0d720ee03e0ca4dabc9.patch";
-      hash = "sha256-hCHOGztZB67vB3hJ6lKdsgiUBw4SdhLQpFZbxKEOSjI=";
-    })
-  ];
+  patches = [ ./3.0.patch ];
   installPhase = ''
     mkdir -p $out
     cp -r * $out/

--- a/lib/rubygems/3.0.patch
+++ b/lib/rubygems/3.0.patch
@@ -1,0 +1,36 @@
+From 0b5bcc8075deaedf692ac0d720ee03e0ca4dabc9 Mon Sep 17 00:00:00 2001
+From: Bob van der Linden <bobvanderlinden@gmail.com>
+Date: Thu, 4 Mar 2021 23:27:40 +0100
+Subject: [PATCH] nix patches
+
+---
+ lib/rubygems/dependency_installer.rb | 2 +-
+ lib/rubygems/path_support.rb         | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/lib/rubygems/dependency_installer.rb b/lib/rubygems/dependency_installer.rb
+index 400a5de5cff..364c0cb9461 100644
+--- a/lib/rubygems/dependency_installer.rb
++++ b/lib/rubygems/dependency_installer.rb
+@@ -16,7 +16,7 @@ class Gem::DependencyInstaller
+   extend Gem::Deprecate
+ 
+   DEFAULT_OPTIONS = { # :nodoc:
+-    :env_shebang         => false,
++    :env_shebang         => true,
+     :document            => %w[ri],
+     :domain              => :both, # HACK dup
+     :force               => false,
+diff --git a/lib/rubygems/path_support.rb b/lib/rubygems/path_support.rb
+index 8103caf3244..d076b1b0a27 100644
+--- a/lib/rubygems/path_support.rb
++++ b/lib/rubygems/path_support.rb
+@@ -23,7 +23,7 @@ class Gem::PathSupport
+   # hashtable, or defaults to ENV, the system environment.
+   #
+   def initialize(env)
+-    @home = env["GEM_HOME"] || Gem.default_dir
++    @home = env["GEM_HOME"] || Gem.user_dir
+ 
+     if File::ALT_SEPARATOR
+       @home = @home.gsub(File::ALT_SEPARATOR, File::SEPARATOR)


### PR DESCRIPTION
It's strange to me that the nix sha could change for the same patch, but it's small enough I figure it'd be easier to inline it to the repo rather than pull it down to make sure it doesn't happen again

Fixes #11

