### PR TITLE
ci: check: restrict concurrency

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch: {}
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build:
 


### PR DESCRIPTION
Currently jobs are running in parallel, which can cause a lot of unnecessary build time. Better to let the caching do its job and cancel already running jobs.