### PR TITLE
renovate: only run every weekend

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,5 +9,8 @@
   "nix": {
     "enabled": true
   },
-  "automerge": true
+  "automerge": true,
+  "schedule": [
+    "every weekend"
+  ]
 }


### PR DESCRIPTION
Renovate might be creating too many update PRs for me to handle. This is to make sure it only runs every weekend.