### PR TITLE
ci: update: supply GITHUB_TOKEN env var

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,6 +15,8 @@ jobs:
     - name: Install Nix
       uses: cachix/install-nix-action@v18
     - run: nix run .#update
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     - uses: stefanzweifel/git-auto-commit-action@v4.16.0
       with:
         commit_message: Update Ruby versions


### PR DESCRIPTION
Currently the update workflow fails because it isn't able to use the GitHub GraphQL APIs without a `GITHUB_TOKEN`. This PR adds the token to the environment.