### PR TITLE
make ruby 3.1.3 use rubygems 3.4

### DIFF
--- a/ruby/overrides.nix
+++ b/ruby/overrides.nix
@@ -2,6 +2,7 @@
 , openssl_1_1
 , rubygems-2_7
 , rubygems-2_6
+, rubygems-3_3
 }:
 [
   {
@@ -31,6 +32,11 @@
   }
   {
     condition = version: with versionComparison version;
+      lessThan "3.1.3";
+    override = pkg: pkg.override { rubygems = rubygems-3_3; };
+  }
+  {
+    condition = version: with versionComparison version;
       lessThan "2.5";
     override = pkg: pkg.override { rubygems = rubygems-2_7; };
   }
@@ -48,10 +54,5 @@
     condition = version: with versionComparison version;
       lessThan "2.0.0";
     override = pkg: pkg.override { libDir = pkg.version; };
-  }
-  {
-    condition = version: with versionComparison version;
-      greaterOrEqualTo "3.1.3";
-    override = pkg: pkg.override { rubygems = null; };
   }
 ]

--- a/rubygems/overrides.nix
+++ b/rubygems/overrides.nix
@@ -5,6 +5,26 @@
 [
   {
     condition = version: with versionComparison version;
+      lessThan "3.4.0";
+    override = pkg: pkg.overrideAttrs (final: prev: {
+      patches = [
+        (fetchpatch {
+          url = "https://raw.githubusercontent.com/NixOS/nixpkgs/cc1bb678f4205ad1c4db34c20b4327cb2cc89a93/pkgs/development/interpreters/ruby/rubygems/0001-add-post-extract-hook.patch";
+          hash = "sha256-kHGcrBMTwixCs06mCPnpv3B3mVseT08izzJ8F7b3u+M=";
+        })
+        (fetchpatch {
+          url = "https://raw.githubusercontent.com/NixOS/nixpkgs/cc1bb678f4205ad1c4db34c20b4327cb2cc89a93/pkgs/development/interpreters/ruby/rubygems/0002-binaries-with-env-shebang.patch";
+          hash = "sha256-DQVwqCRqkjtXNKcUi/363reFUgFsTOb328da3xGnfcY=";
+        })
+        (fetchpatch {
+          url = "https://raw.githubusercontent.com/NixOS/nixpkgs/cc1bb678f4205ad1c4db34c20b4327cb2cc89a93/pkgs/development/interpreters/ruby/rubygems/0003-gem-install-default-to-user.patch";
+          hash = "sha256-8XR1FZ6LFgoNXl/65eeFGmJ8EeJUsVFmELHDAJxS61Q=";
+        })
+      ];
+    });
+  }
+  {
+    condition = version: with versionComparison version;
       lessThan "3.0.0";
     override = pkg: pkg.overrideAttrs (final: prev: {
       dontPatchShebangs = true;

--- a/rubygems/package-fn.nix
+++ b/rubygems/package-fn.nix
@@ -15,8 +15,8 @@ stdenv.mkDerivation {
       hash = "sha256-kHGcrBMTwixCs06mCPnpv3B3mVseT08izzJ8F7b3u+M=";
     })
     (fetchpatch {
-      url = "https://raw.githubusercontent.com/NixOS/nixpkgs/cc1bb678f4205ad1c4db34c20b4327cb2cc89a93/pkgs/development/interpreters/ruby/rubygems/0002-binaries-with-env-shebang.patch";
-      hash = "sha256-DQVwqCRqkjtXNKcUi/363reFUgFsTOb328da3xGnfcY=";
+      url = "https://github.com/bobvanderlinden/rubygems/commit/f0189829b5b101ef200ac6f08b2e1c706eb48721.patch";
+      hash = "sha256-zS+1HQ5mZ+Qm0HAUYJq6BTKRhXfNc+ec8gsEn1tO8+E=";
     })
     (fetchpatch {
       url = "https://raw.githubusercontent.com/NixOS/nixpkgs/cc1bb678f4205ad1c4db34c20b4327cb2cc89a93/pkgs/development/interpreters/ruby/rubygems/0003-gem-install-default-to-user.patch";

--- a/rubygems/versions.json
+++ b/rubygems/versions.json
@@ -171,19 +171,180 @@
     "2.7.6": {
       "url": "http://production.cf.rubygems.org/rubygems/rubygems-2.7.6.tgz",
       "hash": "sha256-Z/cUpYKpzkcbu8tBc3TqnPnAYScchl27DQk/O8M3Hus="
+    },
+    "3.4.1": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.4.1.tar.gz",
+      "hash": "sha256-HE21rW/1Qf3OH1P8agWn4I7peQP1prFBB8hSL4giELw="
+    },
+    "3.4.0": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.4.0.tar.gz",
+      "hash": "sha256-nLwvhhg6gC74PkDIwuNtP6RnQqeTWcI8K1B9dJwbZYs="
+    },
+    "3.2.19": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.2.19.tar.gz",
+      "hash": "sha256-HYGVCsywwE90We/irNcjZGGSASebpuX81VRQf7XMwP4="
+    },
+    "3.2.18": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.2.18.tar.gz",
+      "hash": "sha256-lo1qDPsksk0TkVFTqbbIwNEjlvm2IAJLBrDBS+oQGto="
+    },
+    "3.2.17": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.2.17.tar.gz",
+      "hash": "sha256-D1GzAUa2QMVRYox8QDf9AenF7zzf9vEYpAM6S2v8/VQ="
+    },
+    "3.2.16": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.2.16.tar.gz",
+      "hash": "sha256-WLVdCKwqDIxtfyzo+jChNsyweYx/8fqywxlhbII2lWM="
+    },
+    "3.2.15": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.2.15.tar.gz",
+      "hash": "sha256-DSI/YmZYfM1mp9iRBnx87DpbSPanRnXyYGejV8hL+GE="
+    },
+    "3.2.14": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.2.14.tar.gz",
+      "hash": "sha256-iGIs20REvSgQ87b9WhCg2sRJypom0P5hwdqfA1QpBVA="
+    },
+    "3.2.13": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.2.13.tar.gz",
+      "hash": "sha256-JryDY3Xo4Ww8sd9pxlb6faaPQOK6g/941DUQKbx8rgc="
+    },
+    "3.2.12": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.2.12.tar.gz",
+      "hash": "sha256-iiUak0vVSVKhKvosVkRKLD9ISmsh84Q8ldl/TCsKZFs="
+    },
+    "3.2.11": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.2.11.tar.gz",
+      "hash": "sha256-IQnWtFc7SCyrCXliyEW7+ntQq4J1s6gdU9iEmAGNGWo="
+    },
+    "3.2.10": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.2.10.tar.gz",
+      "hash": "sha256-EUXQ0tsnVPfwvqdk52tEIqtbsgspJwtYR9GwF6lFFtw="
+    },
+    "3.2.9": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.2.9.tar.gz",
+      "hash": "sha256-i8bmZAUbQh2fHP6MKruyE1jsGbDZ/2mGNS863iz+cn0="
+    },
+    "3.2.8": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.2.8.tar.gz",
+      "hash": "sha256-oGKU83fR0Ys80NUH5el8qXLzo8Wn87Y2kY1Jt6cGXgY="
+    },
+    "3.2.7": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.2.7.tar.gz",
+      "hash": "sha256-f24b8Dsfy7sQ81FRaavmSJwFEkhjxjpQZxhevXc58b8="
+    },
+    "3.2.6": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.2.6.tar.gz",
+      "hash": "sha256-nhi5PKDkS5fGXsbKANaf9i80jHlOZuMxps9cuEjrHr8="
+    },
+    "3.2.5": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.2.5.tar.gz",
+      "hash": "sha256-n9Oma8l7nVf1KaguCAdiInQ9PJ8EC6i+W5djAEycUbc="
+    },
+    "3.2.4": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.2.4.tar.gz",
+      "hash": "sha256-oFU+QCACxT7RwbbQzfm1V4pG5T+ZPUlOLZ+h33CC1zo="
+    },
+    "3.2.3": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.2.3.tar.gz",
+      "hash": "sha256-NF1IW/Vp1pqlXZczqcDn8RaK3BfQnU2AcvGBaevIa68="
+    },
+    "3.2.2": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.2.2.tar.gz",
+      "hash": "sha256-V8K1iHFs29RbfKQov1PLCuFc3XS00pllAzTXkC4GMvE="
+    },
+    "3.2.1": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.2.1.tar.gz",
+      "hash": "sha256-koPean9z0yT5iESY8XCawJhRm5kDd6yY9PL/QD8H6XU="
+    },
+    "3.2.0": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.2.0.tar.gz",
+      "hash": "sha256-MbkDNgbBeMShmE8hO6AeDn+l0E36fwUiw2CTV6lGy+g="
+    },
+    "3.2.0.rc.2": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.2.0.rc.2.tar.gz",
+      "hash": "sha256-onsln8K9pefQh5yZBvXsk8QttpszTfHedXwKS50BTb4="
+    },
+    "3.2.0.rc.1": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.2.0.rc.1.tar.gz",
+      "hash": "sha256-iEts335aYuo7EOR2+56ftNTUWj8L5fUeIL1MLkY8Xbg="
+    },
+    "3.1.4": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.1.4.tar.gz",
+      "hash": "sha256-uYBc8Cmy2JPLBOqAygh/TgBE8eLt039azqXnyD35OuM="
+    },
+    "3.1.3": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.1.3.tar.gz",
+      "hash": "sha256-gfjdvbZn4DT4aWxNL+KUKm82dgn8ey/DMt5sjnUpXWw="
+    },
+    "3.0.8": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.0.8.tar.gz",
+      "hash": "sha256-+bFsXtKqXQAXNTMcZz8b9Lji6KhLnMpoGFsvgR/yQHc="
+    },
+    "3.0.7": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.0.7.tar.gz",
+      "hash": "sha256-7IaCV77jolEYjuUoXregV+mr7E9EYJ5tywbXOeQ7EkI="
+    },
+    "3.1.2": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.1.2.tar.gz",
+      "hash": "sha256-8q839YH3hl5XVW316xoiBjmURs4Qkit57D5EchzZwzk="
+    },
+    "3.1.1": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.1.1.tar.gz",
+      "hash": "sha256-V55mRzfw3Soet8NY07aI5A4nXeU1VL4qExA5oyc0C8I="
+    },
+    "3.1.0": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v3.1.0.tar.gz",
+      "hash": "sha256-5n1shPmwKa2W9YrYn3benTEwTn+D2GiTcqyglwE5Jag="
+    },
+    "2.7.2": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v2.7.2.tar.gz",
+      "hash": "sha256-zVUkilfPmrxn90WT47V6GNih6i19Le1VPTlvTcGMkpA="
+    },
+    "2.2.3": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v2.2.3.tar.gz",
+      "hash": "sha256-BXUC6ZpIbmq1b6xu3vAL6UpPvZOeUfGXqRR41DG/O4w="
+    },
+    "2.0.15": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v2.0.15.tar.gz",
+      "hash": "sha256-K59HpYy9snNQHxjuGaWErv4imIKmUtNqufXsUYypdaw="
+    },
+    "1.8.30": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v1.8.30.tar.gz",
+      "hash": "sha256-XsGBXw60FTE7M0EgKY/JIj2ejRYv3xT7wNy3SRMag28="
+    },
+    "2.0.5": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v2.0.5.tar.gz",
+      "hash": "sha256-N7hB65c/78SX3lFfPwXbB+uvo1WeQY6lsBL9ieAeaDM="
+    },
+    "2.0.4": {
+      "url": "https://github.com/rubygems/rubygems/archive/refs/tags/v2.0.4.tar.gz",
+      "hash": "sha256-bPC8fw5Zl/mWy8i6oysighm20hfxntIBBy+7ZvmD3OI="
     }
   },
   "aliases": {
+    "1": "1.8.30",
     "2": "2.7.6",
-    "3": "3.3.26",
-    "": "3.3.26",
+    "3": "3.4.1",
+    "": "3.4.1",
+    "3.4": "3.4.1",
     "3.3": "3.3.26",
     "3.2": "3.2.33",
+    "3.1": "3.1.4",
+    "3.0": "3.0.8",
     "2.7": "2.7.6",
     "2.6": "2.6.14",
+    "2.2": "2.2.3",
+    "2.0": "2.0.15",
+    "1.8": "1.8.30",
+    "3_4": "3.4.1",
     "3_3": "3.3.26",
     "3_2": "3.2.33",
+    "3_1": "3.1.4",
+    "3_0": "3.0.8",
     "2_7": "2.7.6",
-    "2_6": "2.6.14"
+    "2_6": "2.6.14",
+    "2_2": "2.2.3",
+    "2_0": "2.0.15",
+    "1_8": "1.8.30"
   }
 }


### PR DESCRIPTION
Rubygems 3.4 came out later than Ruby 3.1.3. Ruby 3.1.3 had previously disabled custom rubygems, as the build was failing. Now that Rubygems 3.4 is out, we can make use of this again.

Rubygems 3.4 did need a new patch for enabling env_shebang again, which is also included in this PR.