### PR TITLE
ci: update: create pull requests instead of commits directly on master

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "30 5 * * *"
   workflow_dispatch: {}
+permissions:
+  pull-requests: write
+  contents: write
 jobs:
   build:
 
@@ -17,8 +20,17 @@ jobs:
     - run: nix run .#update
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-    - uses: stefanzweifel/git-auto-commit-action@v4.16.0
+    - name: Create Pull Request
+      id: create-pull-request
+      uses: peter-evans/create-pull-request@v3
       with:
-        commit_message: Update Ruby versions
-        branch: master
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: Update Ruby versions
+        title: Update Ruby versions
+        delete-branch: true
+        branch: update-ruby-versions
+    - uses: peter-evans/enable-pull-request-automerge@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        pull-request-number: ${{ steps.create-pull-request.outputs.pull-request-number }}
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -27,6 +27,16 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: Update Ruby versions
         title: Update Ruby versions
+        body: |
+          Automatically created pull-request to update Ruby and Rubygems versions.
+          
+          This is the result of running:
+
+          ```
+          nix run .#update
+          ```
+
+          See the workflow here: https://github.com/bobvanderlinden/nixpkgs-ruby/blob/master/.github/workflows/update.yml
         delete-branch: true
         branch: update-ruby-versions
     - uses: peter-evans/enable-pull-request-automerge@v2


### PR DESCRIPTION
Currently the update workflow automatically creates commits directly on master. Since #23 we have CI that can check for build failures, which is something we'd like before committing to master.

For this we can make pull requests that will automatically be merged once the PR's checks succeed.