### PR TITLE
Add support for Ruby 3.2 YJIT

### DIFF
--- a/ruby/overrides.nix
+++ b/ruby/overrides.nix
@@ -55,4 +55,9 @@
       lessThan "2.0.0";
     override = pkg: pkg.override { libDir = pkg.version; };
   }
+  {
+    condition = version: with versionComparison version;
+      lessThan "3.2";
+    override = pkg: pkg.override { yjitSupport = false; };
+  }
 ]

--- a/ruby/package-fn.nix
+++ b/ruby/package-fn.nix
@@ -31,6 +31,8 @@
 , docSupport ? false
 , yamlSupport ? true
 , fiddleSupport ? true
+, yjitSupport ? true
+, rustc
 }:
 let
   op = lib.optional;
@@ -71,6 +73,7 @@ let
         ++ (op opensslSupport openssl)
         ++ (op gdbmSupport gdbm)
         ++ (op yamlSupport libyaml)
+        ++ (op yjitSupport rustc)
         # Looks like ruby fails to build on darwin without readline even if curses
         # support is not enabled, so add readline to the build inputs if curses
         # support is disabled (if it's enabled, we already have it) and we're


### PR DESCRIPTION
In Ruby 3.2 YJIT is [no longer experimental](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/) so enable it by default on 3.2+ builds. It requires rustc >= 1.58.0 in order to be built.