### PR TITLE
Fix ruby-version determination

### DIFF
--- a/template/flake.nix
+++ b/template/flake.nix
@@ -10,8 +10,9 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        rubyVersion = nixpkgs.lib.fileContents ./.ruby-version;
-        ruby = nixpkgs-ruby.packages.${system}.ruby-${rubyVersion};
+        rubyVersion = nixpkgs.lib.strings.removePrefix "ruby-"
+          (nixpkgs.lib.fileContents ./.ruby-version);
+        ruby = nixpkgs-ruby.packages.${system}."ruby-${rubyVersion}";       
 
         gems = pkgs.bundlerEnv {
           name = "gemset";


### PR DESCRIPTION
1. sometimes the `.ruby-version` contains a `ruby-` prefix, so this'll strip it.
2. I had to wrap the ruby portion of the package name with "

I'm sort of fumbling here but this works for me locally.