### PR TITLE
simplify openssl-1.1 condition

### DIFF
--- a/ruby/overrides.nix
+++ b/ruby/overrides.nix
@@ -27,7 +27,7 @@
   }
   {
     condition = version: with versionComparison version;
-      (lessThan "3.0") || (hasPrefix "3.0" && lessThan "3.0.3");
+      lessThan "3.0.3";
     override = pkg: pkg.override { openssl = openssl_1_1; };
   }
   {


### PR DESCRIPTION
The expression was superfluous and could be simplified to be more readable.