### PR TITLE
ruby: remove unused rubygems references

### DIFF
--- a/ruby/overrides.nix
+++ b/ruby/overrides.nix
@@ -1,8 +1,5 @@
 { versionComparison
 , openssl_1_1
-, rubygems-2_7
-, rubygems-2_6
-, rubygems-3_3
 }:
 [
   {


### PR DESCRIPTION
The rubygems inclusions were removed in #39. These references were still left-over and are not needed anymore.