### PR TITLE
ruby: passthru libDir in version

### DIFF
--- a/ruby/package-fn.nix
+++ b/ruby/package-fn.nix
@@ -154,7 +154,9 @@ let
       };
 
       passthru = {
-        version = import ./parse-version.nix version;
+        version = {
+          inherit libDir;
+        } // (import ./parse-version.nix version);
         rubyEngine = "ruby";
         libPath = "lib/${self.passthru.rubyEngine}/${libDir}";
         gemPath = "lib/${self.passthru.rubyEngine}/gems/${libDir}";


### PR DESCRIPTION
`libDir` was not available as an attribute of Ruby's version attrset, which makes devenv and probably more Ruby related helpers fail.