### PR TITLE
add jemalloc support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -138,6 +138,14 @@
                   ruby -e 'puts "ok"' > $out
                 '';
               };
+              "${rubyName}-jemalloc" = {
+                nativeBuildInputs = [
+                  (ruby.override { jemallocSupport = true; })
+                ];
+                command = ''
+                  ruby -e 'puts "ok"' > $out
+                '';
+              };
               "${rubyName}-mkRuby" = {
                 nativeBuildInputs = [
                   (self.lib.mkRuby {
@@ -197,7 +205,7 @@
                     ruby -e 'puts RUBY_VERSION' > $out
                   '';
                 };
-            packageFromRubyVersionFileWithEngine = 
+            packageFromRubyVersionFileWithEngine =
               let
                 ruby = self.lib.packageFromRubyVersionFile {
                   file = ./tests/ruby-version-with-engine;

--- a/ruby/package-fn.nix
+++ b/ruby/package-fn.nix
@@ -34,6 +34,8 @@
 , fiddleSupport ? true
 , yjitSupport ? true
 , rustc
+, jemallocSupport ? false
+, jemalloc
 }:
 let
   op = lib.optional;
@@ -75,6 +77,7 @@ let
         ++ (op gdbmSupport gdbm)
         ++ (op yamlSupport libyaml)
         ++ (op yjitSupport rustc)
+        ++ (op jemallocSupport jemalloc)
         # Looks like ruby fails to build on darwin without readline even if curses
         # support is not enabled, so add readline to the build inputs if curses
         # support is disabled (if it's enabled, we already have it) and we're
@@ -109,6 +112,7 @@ let
       configureFlags =
         [ "--enable-shared" "--enable-pthread" ]
         ++ op (!docSupport) "--disable-install-doc"
+        ++ op jemallocSupport "--with-jemalloc"
         ++ ops stdenv.isDarwin [
           # on darwin, we have /usr/include/tk.h -- so the configure script detects
           # that tk is installed


### PR DESCRIPTION
jemalloc is often a more optimal memory allocator for Ruby workloads.