### PR TITLE
Add openssl test

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -145,6 +145,14 @@
                   ruby -e 'puts "ok"' > $out
                 '';
               };
+              "${rubyName}-openssl" = {
+                nativeBuildInputs = [
+                  ruby
+                ];
+                command = ''
+                  ruby -e 'require "openssl"; puts OpenSSL::OPENSSL_VERSION' > $out
+                '';
+              };
             } // (lib.optionalAttrs (with import ./lib/version-comparison.nix rubyVersion; greaterOrEqualTo "2.2") {
               "${rubyName}-bundlerEnv" = let
                 gems = pkgs.bundlerEnv {

--- a/flake.nix
+++ b/flake.nix
@@ -145,6 +145,9 @@
                   ruby -e 'puts "ok"' > $out
                 '';
               };
+            } // (lib.optionalAttrs (with versionComparison rubyVersion; greaterOrEqualTo "2.4") {
+              # Ruby <2.4 only supports openssl 1.0 and not openssl1.1. openssl 1.0 is not supported by nixpkgs
+              # anymore, so we will not support it here.
               "${rubyName}-openssl" = {
                 nativeBuildInputs = [
                   ruby
@@ -153,7 +156,7 @@
                   ruby -e 'require "openssl"; puts OpenSSL::OPENSSL_VERSION' > $out
                 '';
               };
-            } // (lib.optionalAttrs (with import ./lib/version-comparison.nix rubyVersion; greaterOrEqualTo "2.2") {
+            }) // (lib.optionalAttrs (with versionComparison rubyVersion; greaterOrEqualTo "2.2") {
               "${rubyName}-bundlerEnv" = let
                 gems = pkgs.bundlerEnv {
                   name = "gemset";

--- a/ruby/overrides.nix
+++ b/ruby/overrides.nix
@@ -24,7 +24,7 @@
   }
   {
     condition = version: with versionComparison version;
-      lessThan "3.0.3";
+      lessThan "3.1";
     override = pkg: pkg.override { openssl = openssl_1_1; };
   }
   {


### PR DESCRIPTION
As mentioned in #6, there are Ruby versions where openssl does not correctly work.
The intention is to add tests for loading the openssl gem so that we can detect for which versions openssl does and does not work.

After that it is likely that overrides are needed to change the openssl version for specific Ruby versions.