### PR TITLE
Add .ruby-version as a cache key in nix-direnv

### DIFF
--- a/template/.envrc
+++ b/template/.envrc
@@ -1,1 +1,2 @@
+nix_direnv_watch_file .ruby-version
 use flake


### PR DESCRIPTION
When I changed the .ruby-version, nix-direnv did not update flake.lock and paths.
As I understand it, this template assumes that nix-direnv is used, so adding .ruby-version as a cache key may be useful?

https://github.com/bobvanderlinden/nixpkgs-ruby/blob/509892e8018ca45f84bbe2650f2bcebc42c4c593/README.md#L57
https://github.com/nix-community/nix-direnv/blob/ed2cb75553b4864e3c931a48e3a2cd43b93152c5/README.md?plain=1#L368-L373

NOTE: In my understanding, direnv can handle some function of `use flake` syntax without nix-direnv, for the direnv only users, this syntax raise errors as follows

```
direnv: loading ~/repos/ruby-ulid/.envrc
./.envrc:1: nix_direnv_watch_file: command not found
direnv: using flake
```