### PR TITLE
nix_direnv_watch_file is deprecated

### DIFF
--- a/template/.envrc
+++ b/template/.envrc
@@ -1,2 +1,2 @@
-nix_direnv_watch_file .ruby-version
+watch_file .ruby-version
 use flake


### PR DESCRIPTION
`direnv` was showing the following error message:

```
direnv: `nix_direnv_watch_file` is deprecated - use `watch_file`
```

---

`nix_direnv_watch_file` is deprecated

 `watch_file` is favored since nix-direnv 3.0.0

cf. https://github.com/nix-community/nix-direnv/releases/tag/3.0.0 

cf. https://github.com/nix-community/nix-direnv/pull/438