### PR TITLE
nixpkgs: permit openssl-1.1.1w explicitly

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,4 +27,4 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - uses: actions/checkout@v4
       - name: nix flake check
-        run: NIXPKGS_ALLOW_INSECURE=1 NIXPKGS_ALLOW_BROKEN=1 nix flake check --print-build-logs --keep-going --impure
+        run: NIXPKGS_ALLOW_BROKEN=1 nix flake check --print-build-logs --keep-going --impure

--- a/.github/workflows/flakehub-publish-rolling.yml
+++ b/.github/workflows/flakehub-publish-rolling.yml
@@ -18,5 +18,3 @@ jobs:
           rolling: true
           visibility: "public"
           include-output-paths: true
-        env:
-          NIXPKGS_ALLOW_INSECURE: 1

--- a/flake.nix
+++ b/flake.nix
@@ -111,6 +111,9 @@
         overlays = [
           self.overlays.default
         ];
+        config.permittedInsecurePackages = [
+          "openssl-1.1.1w"
+        ];
       };
     in
     {


### PR DESCRIPTION
Fixes https://github.com/bobvanderlinden/nixpkgs-ruby/issues/89

Explicitly permit openssl 1.1.1w, so that legacy ruby versions can be used without needing `--impure` and `NIXPKGS_ALLOW_INSECURE=1` or overriding pkgs.

This will also allow pushing to flakehub.