### PR TITLE
remove legacy apple_sdk.frameworks

### DIFF
--- a/ruby/package-fn.nix
+++ b/ruby/package-fn.nix
@@ -82,7 +82,6 @@ let
         # support is disabled (if it's enabled, we already have it) and we're
         # running on darwin
         ++ (op (!cursesSupport && stdenv.isDarwin) readline)
-        ++ (op stdenv.isDarwin darwin.apple_sdk.frameworks.Foundation)
         ++ (ops stdenv.isDarwin
           (with darwin; [ libiconv libobjc libunwind ]));
       propagatedBuildInputs =


### PR DESCRIPTION
These frameworks are stubs and are not needed to be referenced explicitly anymore. See https://nixos.org/manual/nixpkgs/stable/#sec-darwin-legacy-frameworks. 