### PR TITLE
ci: run pure flake check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,4 +27,4 @@ jobs:
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - uses: actions/checkout@v4
       - name: nix flake check
-        run: NIXPKGS_ALLOW_BROKEN=1 nix flake check --print-build-logs --keep-going --impure
+        run: nix flake check --print-build-logs --keep-going


### PR DESCRIPTION
Currently there are no broken packages exposed, so we can run the flake check without `NIXPKGS_ALLOW_BROKEN` and without `--impure`.