### PR TITLE
Fix darwin.libobjc warning for NixOS 25.05

### DIFF
--- a/ruby/package-fn.nix
+++ b/ruby/package-fn.nix
@@ -19,7 +19,8 @@
 , libffi
 , bison
 , autoconf
-, darwin ? null
+, libiconv
+, libunwind
 , buildEnv
 , bundler
 , bundix
@@ -82,8 +83,7 @@ let
         # support is disabled (if it's enabled, we already have it) and we're
         # running on darwin
         ++ (op (!cursesSupport && stdenv.isDarwin) readline)
-        ++ (ops stdenv.isDarwin
-          (with darwin; [ libiconv libobjc libunwind ]));
+        ++ (ops stdenv.isDarwin [ libiconv libunwind ]);
       propagatedBuildInputs =
         (op jemallocSupport jemalloc);
 


### PR DESCRIPTION
At this point darwin.libobjc is a stub and will be removed in NixOS 25.11[1][2]. I tried to keep the shape close to ruby in nixpkgs minus the formatting.

[1] https://github.com/NixOS/nixpkgs/blob/497e86a244d2605190e9ca2c1d74100d54fc57fe/pkgs/os-specific/darwin/apple-sdk/mk-stub.nix#L5
[2] https://github.com/NixOS/nixpkgs/blob/497e86a244d2605190e9ca2c1d74100d54fc57fe/pkgs/top-level/darwin-aliases.nix#L88