### PR TITLE
test: add docSupport test and add docSupport version check

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
           versionedPackageFnWithOverrides = { version, versionSource }:
             let pkg =
               pkgs.callPackage packageFn {
-                inherit version versionSource;
+                inherit version versionSource versionComparison;
               };
             in
             applyOverrides {
@@ -189,6 +189,24 @@
                 ];
                 command = ''
                   ruby -e 'require "foobar"; say' > $out
+                '';
+              };
+            }) // (lib.optionalAttrs (with versionComparison rubyVersion; greaterOrEqualTo "3.4") {
+              "${rubyName}-docSupport" = {
+                nativeBuildInputs = [
+                  (ruby.override { docSupport = true; })
+                ];
+                command = ''
+                  ri Array > $out
+                '';
+              };
+            }) // (lib.optionalAttrs (with versionComparison rubyVersion; lessThan "3.4") {
+              "${rubyName}-docSupport-noParallel" = {
+                nativeBuildInputs = [
+                  (ruby.override { docSupport = true; parallelBuild = false; })
+                ];
+                command = ''
+                  ri Array > $out
                 '';
               };
             })

--- a/flake.nix
+++ b/flake.nix
@@ -197,7 +197,7 @@
                   (ruby.override { docSupport = true; })
                 ];
                 command = ''
-                  ri Array > $out
+                  HOME=$TMPDIR ri Array > $out
                 '';
               };
             }) // (lib.optionalAttrs (with versionComparison rubyVersion; lessThan "3.4") {
@@ -206,7 +206,7 @@
                   (ruby.override { docSupport = true; parallelBuild = false; })
                 ];
                 command = ''
-                  ri Array > $out
+                  HOME=$TMPDIR ri Array > $out
                 '';
               };
             })

--- a/ruby/package-fn.nix
+++ b/ruby/package-fn.nix
@@ -109,6 +109,11 @@ let
 
       preConfigure = ''
         sed -i configure -e 's/;; #(/\n;;/g'
+        ${opString docSupport ''
+          # rdoc creates XDG_DATA_DIR (defaulting to $HOME/.local/share) even if
+          # it's not going to be used.
+          export HOME=$TMPDIR
+        ''}
       '';
 
       configureFlags =

--- a/rubygems/package-fn.nix
+++ b/rubygems/package-fn.nix
@@ -3,6 +3,7 @@
 , stdenv
 , fetchurl
 , fetchpatch
+, ...
 }:
 stdenv.mkDerivation {
   pname = "rubygems";


### PR DESCRIPTION
There is a do-install-doc issue related to ruby version < 3.4.
This commit checks doc support for ruby version >= 3.4 and add guard
perventing docSupport be used in parallel build with early versions.

See: https://github.com/ruby/rubygems/issues/7580
