### PR TITLE
Fix docSupport build failure in Nix sandbox

### DIFF
--- a/ruby/package-fn.nix
+++ b/ruby/package-fn.nix
@@ -107,6 +107,11 @@ let
 
       preConfigure = ''
         sed -i configure -e 's/;; #(/\n;;/g'
+        ${opString docSupport ''
+          # rdoc creates XDG_DATA_DIR (defaulting to $HOME/.local/share) even if
+          # it's not going to be used.
+          export HOME=$TMPDIR
+        ''}
       '';
 
       configureFlags =


### PR DESCRIPTION
rdoc tries to create XDG_DATA_DIR (defaulting to $HOME/.local/share) during the build, but $HOME is read-only in the Nix sandbox.

This adds a writable $HOME during the preConfigure phase.