### PR TITLE
test: add docSupport test and add docSupport version check

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
             { version, versionSource }:
             let
               pkg = pkgs.callPackage packageFn {
-                inherit version versionSource;
+                inherit version versionSource versionComparison;
               };
             in
             applyOverrides {
@@ -216,6 +216,29 @@
                 ];
                 command = ''
                   ruby -e 'require "openssl"; puts OpenSSL::OPENSSL_VERSION' > $out
+                '';
+              };
+            })
+            // (lib.optionalAttrs (with versionComparison rubyVersion; greaterOrEqualTo "3.4") {
+              docSupport = {
+                nativeBuildInputs = [
+                  (ruby.override { docSupport = true; })
+                ];
+                command = ''
+                  ri Array > $out
+                '';
+              };
+            })
+            // (lib.optionalAttrs (with versionComparison rubyVersion; lessThan "3.4") {
+              docSupport-noParallel = {
+                nativeBuildInputs = [
+                  (ruby.override {
+                    docSupport = true;
+                    parallelBuild = false;
+                  })
+                ];
+                command = ''
+                  ri Array > $out
                 '';
               };
             })

--- a/flake.nix
+++ b/flake.nix
@@ -225,7 +225,7 @@
                   (ruby.override { docSupport = true; })
                 ];
                 command = ''
-                  ri Array > $out
+                  HOME=$TMPDIR ri Array > $out
                 '';
               };
             })
@@ -238,7 +238,7 @@
                   })
                 ];
                 command = ''
-                  ri Array > $out
+                  HOME=$TMPDIR ri Array > $out
                 '';
               };
             })

--- a/ruby/package-fn.nix
+++ b/ruby/package-fn.nix
@@ -1,6 +1,8 @@
 {
   version,
-  versionSource,
+  versionSource
+, versionComparison
+,
   libDir ? "${(import ./parse-version.nix version).majMin}.0",
   rubygems ? null,
   stdenv,
@@ -25,7 +27,9 @@
   buildEnv,
   bundler,
   bundix,
-  removeReferencesTo,
+  removeReferencesTo
+, parallelBuild ? true
+,
   useRailsExpress ? true,
   zlibSupport ? true,
   opensslSupport ? true,
@@ -89,7 +93,7 @@ let
       ]);
     propagatedBuildInputs = (op jemallocSupport jemalloc);
 
-    enableParallelBuilding = true;
+    enableParallelBuilding = parallelBuild;
 
     postPatch = ''
       ${opString (rubygems != null) ''
@@ -200,4 +204,7 @@ let
     };
   };
 in
+# There's a known race condition when building with docs enabled before Ruby 3.4.0
+# Building documents requires parallelBuild to be false in those versions
+assert docSupport -> (with versionComparison version; greaterOrEqualTo "3.4.0" || !parallelBuild);
 self

--- a/ruby/package-fn.nix
+++ b/ruby/package-fn.nix
@@ -113,6 +113,11 @@ let
 
     preConfigure = ''
       sed -i configure -e 's/;; #(/\n;;/g'
+      ${opString docSupport ''
+        # rdoc creates XDG_DATA_DIR (defaulting to $HOME/.local/share) even if
+        # it's not going to be used.
+        export HOME=$TMPDIR
+      ''}
     '';
 
     configureFlags =

--- a/rubygems/package-fn.nix
+++ b/rubygems/package-fn.nix
@@ -4,6 +4,7 @@
   stdenv,
   fetchurl,
   fetchpatch,
+  ...
 }:
 stdenv.mkDerivation {
   pname = "rubygems";


### PR DESCRIPTION
Duplicate of #212 but updated to use parallel CI from #225, so that builds won't timeout on GHA.

Closes #212 
Closes #221 