### PR TITLE
Group tests and execute groups in parallel

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -57,3 +57,21 @@ jobs:
         run: |
           installable='.#checkBatches.${{ matrix.system }}."${{ matrix.group }}".all'
           nix build --print-build-logs --keep-going "$installable"
+
+  all_checks:
+    if: ${{ always() }}
+    needs:
+      - eval
+      - prepare-matrix
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require successful checks
+        env:
+          EVAL_RESULT: ${{ needs.eval.result }}
+          PREPARE_MATRIX_RESULT: ${{ needs.prepare-matrix.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: |
+          test "$EVAL_RESULT" = success
+          test "$PREPARE_MATRIX_RESULT" = success
+          test "$BUILD_RESULT" = success

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,17 +6,55 @@ on:
       - master
   pull_request: {}
   workflow_dispatch: {}
+
 permissions:
   contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
 jobs:
+  eval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+      - name: nix flake check --no-build
+        run: nix flake check --all-systems --no-build
+
+  prepare-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+      - id: matrix
+        name: Generate build matrix
+        run: |
+          linux_groups="$(nix eval --json .#checkBatches.x86_64-linux --apply builtins.attrNames)"
+          darwin_groups="$(nix eval --json .#checkBatches.aarch64-darwin --apply builtins.attrNames)"
+          matrix="$(jq --null-input --compact-output \
+            --argjson linux_groups "$linux_groups" \
+            --argjson darwin_groups "$darwin_groups" '
+              {
+                include:
+                  ([ $linux_groups[] | { os: "ubuntu-latest", system: "x86_64-linux", group: . } ] +
+                   [ $darwin_groups[] | { os: "macos-latest", system: "aarch64-darwin", group: . } ])
+              }
+            ')"
+          printf 'matrix=%s\n' "$matrix" >> "$GITHUB_OUTPUT"
+
   build:
+    needs:
+      - eval
+      - prepare-matrix
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Nix
@@ -26,5 +64,7 @@ jobs:
           name: nixpkgs-ruby
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - uses: actions/checkout@v6
-      - name: nix flake check
-        run: nix flake check --print-build-logs --keep-going
+      - name: nix build check batch
+        run: |
+          installable='.#checkBatches.${{ matrix.system }}."${{ matrix.group }}".all'
+          nix build --print-build-logs --keep-going "$installable"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,19 +34,7 @@ jobs:
         uses: cachix/install-nix-action@v31
       - id: matrix
         name: Generate build matrix
-        run: |
-          linux_groups="$(nix eval --json .#checkBatches.x86_64-linux --apply builtins.attrNames)"
-          darwin_groups="$(nix eval --json .#checkBatches.aarch64-darwin --apply builtins.attrNames)"
-          matrix="$(jq --null-input --compact-output \
-            --argjson linux_groups "$linux_groups" \
-            --argjson darwin_groups "$darwin_groups" '
-              {
-                include:
-                  ([ $linux_groups[] | { os: "ubuntu-latest", system: "x86_64-linux", group: . } ] +
-                   [ $darwin_groups[] | { os: "macos-latest", system: "aarch64-darwin", group: . } ])
-              }
-            ')"
-          printf 'matrix=%s\n' "$matrix" >> "$GITHUB_OUTPUT"
+        run: nix run .#gha-prepare-matrix
 
   build:
     needs:
@@ -54,7 +42,8 @@ jobs:
       - prepare-matrix
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
+      matrix:
+        include: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Nix

--- a/flake.nix
+++ b/flake.nix
@@ -311,9 +311,35 @@
             value = checkDrv;
           }) (lib.removeAttrs batchChecks [ "all" ])
         ) checkBatches;
+        ghaMatrixEntries =
+          (builtins.map (group: {
+            os = "ubuntu-latest";
+            system = "x86_64-linux";
+            inherit group;
+          }) (builtins.attrNames self.checkBatches.x86_64-linux))
+          ++ (builtins.map (group: {
+            os = "macos-latest";
+            system = "aarch64-darwin";
+            inherit group;
+          }) (builtins.attrNames self.checkBatches.aarch64-darwin));
+        ghaPrepareMatrix = pkgs.writeShellApplication {
+          name = "gha-prepare-matrix";
+          text = ''
+            matrix=${lib.escapeShellArg (builtins.toJSON ghaMatrixEntries)}
+
+            if [ -n "''${GITHUB_OUTPUT:-}" ]; then
+              printf 'matrix=%s\n' "$matrix" >> "$GITHUB_OUTPUT"
+            else
+              printf 'warning: GITHUB_OUTPUT is not set; writing matrix to stdout\n' >&2
+              printf 'matrix=%s\n' "$matrix"
+            fi
+          '';
+        };
       in
       {
-        packages = intactPackages;
+        packages = intactPackages // {
+          gha-prepare-matrix = ghaPrepareMatrix;
+        };
 
         checkBatches = checkBatches;
 
@@ -330,27 +356,34 @@
           };
         };
 
-        apps.update = {
-          type = "app";
-          program =
-            let
-              inherit (builtins)
-                concatStringsSep
-                ;
-              inherit (nixpkgs.lib) mapAttrsToList filterAttrs;
-              pkgsetsToUpdate = filterAttrs (name: pkgset: pkgset ? updater) _pkgsets;
-              updateCommand = name: pkgset: ''
-                echo "Updating ${name}..."
-                (cd ${name} && ${pkgs.callPackage pkgset.updater { }}/bin/update)
-              '';
-              updateCommands = mapAttrsToList updateCommand pkgsetsToUpdate;
-              script = pkgs.writeScript "update" ''
-                #!${pkgs.bash}/bin/bash
-                set -o errexit
-                ${concatStringsSep "\n" updateCommands}
-              '';
-            in
-            "${script}";
+        apps = {
+          gha-prepare-matrix = {
+            type = "app";
+            program = "${ghaPrepareMatrix}/bin/gha-prepare-matrix";
+          };
+
+          update = {
+            type = "app";
+            program =
+              let
+                inherit (builtins)
+                  concatStringsSep
+                  ;
+                inherit (nixpkgs.lib) mapAttrsToList filterAttrs;
+                pkgsetsToUpdate = filterAttrs (name: pkgset: pkgset ? updater) _pkgsets;
+                updateCommand = name: pkgset: ''
+                  echo "Updating ${name}..."
+                  (cd ${name} && ${pkgs.callPackage pkgset.updater { }}/bin/update)
+                '';
+                updateCommands = mapAttrsToList updateCommand pkgsetsToUpdate;
+                script = pkgs.writeScript "update" ''
+                  #!${pkgs.bash}/bin/bash
+                  set -o errexit
+                  ${concatStringsSep "\n" updateCommands}
+                '';
+              in
+              "${script}";
+          };
         };
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -45,12 +45,11 @@
             version: versionSource: versionedPackageFnWithOverrides { inherit version versionSource; }
           ) versions.sources;
           packageAliases = builtins.mapAttrs (alias: version: packageVersions.${version}) versions.aliases;
-          packages = nixpkgs.lib.mapAttrs' (version: package: {
-            name = version;
-            value = package;
-          }) (packageAliases // packageVersions);
         in
-        packages;
+        nixpkgs.lib.mapAttrs' (version: package: {
+          name = version;
+          value = package;
+        }) (packageAliases // packageVersions);
       mkPkgSet =
         {
           pname,
@@ -113,6 +112,7 @@
             rubyEngine = builtins.head segments;
             version = builtins.concatStringsSep "-" (builtins.tail segments);
           };
+
       lib.packageFromRubyVersionFile =
         { file, system }:
         let
@@ -143,11 +143,11 @@
           default = nixpkgs.lib.composeManyExtensions (builtins.attrValues pkgsetOverlays);
         }
         // pkgsetOverlays;
-
     }
     // flake-utils.lib.eachDefaultSystem (
       system:
       let
+        lib = nixpkgs.lib;
         pkgs = import nixpkgs {
           inherit system;
           overlays = [
@@ -158,101 +158,97 @@
           ];
         };
 
-        allPackages = nixpkgs.lib.concatMapAttrs (name: pkgset: pkgset pkgs) pkgsets;
-        intactPackages = nixpkgs.lib.filterAttrs (name: package: !package.meta.broken) allPackages;
-      in
-      {
-        packages = intactPackages;
-
-        checks =
-          let
-            lib = nixpkgs.lib;
-            mkTest =
-              {
-                name,
-                command,
-                env ? { },
-                nativeBuildInputs ? [ ],
-              }:
-              pkgs.runCommand name ({ inherit nativeBuildInputs; } // env) command;
-            rubyPackages = lib.filterAttrs (
-              name: package: (builtins.match "ruby-[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+" name) != null
-            ) intactPackages;
-            rubyTestAttrs = lib.concatMapAttrs (
-              rubyName: ruby:
-              let
-                rubyVersion = nixpkgs.lib.removePrefix "ruby-" rubyName;
-              in
-              {
-                "${rubyName}-puts-ok" = {
-                  nativeBuildInputs = [
-                    ruby
-                  ];
-                  command = ''
-                    ruby -e 'puts "ok"' > $out
-                  '';
-                };
-                "${rubyName}-jemalloc" = {
-                  nativeBuildInputs = [
-                    (ruby.override { jemallocSupport = true; })
-                  ];
-                  command = ''
-                    ruby -e 'puts "ok"' > $out
-                  '';
-                };
-                "${rubyName}-mkRuby" = {
-                  nativeBuildInputs = [
-                    (self.lib.mkRuby {
-                      inherit pkgs rubyVersion;
-                    })
-                  ];
-                  command = ''
-                    ruby -e 'puts "ok"' > $out
-                  '';
-                };
-              }
-              // (lib.optionalAttrs (with versionComparison rubyVersion; greaterOrEqualTo "2.4") {
-                # Ruby <2.4 only supports openssl 1.0 and not openssl1.1. openssl 1.0 is not supported by nixpkgs
-                # anymore, so we will not support it here.
-                "${rubyName}-openssl" = {
-                  nativeBuildInputs = [
-                    ruby
-                  ];
-                  command = ''
-                    ruby -e 'require "openssl"; puts OpenSSL::OPENSSL_VERSION' > $out
-                  '';
-                };
-              })
-              // (lib.optionalAttrs (with versionComparison rubyVersion; greaterOrEqualTo "2.2") {
-                "${rubyName}-bundlerEnv" =
-                  let
-                    gems = pkgs.bundlerEnv {
-                      name = "gemset";
-                      inherit ruby;
-                      gemfile = ./tests/bundlerEnv/Gemfile;
-                      lockfile = ./tests/bundlerEnv/Gemfile.lock;
-                      gemset = ./tests/bundlerEnv/gemset.nix;
-                      groups = [
-                        "default"
-                        "production"
-                        "development"
-                        "test"
-                      ];
-                    };
-                  in
-                  {
-                    nativeBuildInputs = [
-                      self.packages.${pkgs.system}.${rubyName}
-                      gems
+        allPackages = lib.concatMapAttrs (name: pkgset: pkgset pkgs) pkgsets;
+        intactPackages = lib.filterAttrs (name: package: !package.meta.broken) allPackages;
+        rubyPackages = lib.filterAttrs (
+          name: package: (builtins.match "ruby-[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+" name) != null
+        ) intactPackages;
+        mkTest =
+          {
+            name,
+            command,
+            env ? { },
+            nativeBuildInputs ? [ ],
+          }:
+          pkgs.runCommand name ({ inherit nativeBuildInputs; } // env) command;
+        flattenCheckName =
+          groupName: testName: if groupName == "common" then testName else "${groupName}-${testName}";
+        checkBatchAttrs =
+          lib.mapAttrs (
+            rubyName: ruby:
+            let
+              rubyVersion = lib.removePrefix "ruby-" rubyName;
+            in
+            {
+              puts-ok = {
+                nativeBuildInputs = [
+                  ruby
+                ];
+                command = ''
+                  ruby -e 'puts "ok"' > $out
+                '';
+              };
+              jemalloc = {
+                nativeBuildInputs = [
+                  (ruby.override { jemallocSupport = true; })
+                ];
+                command = ''
+                  ruby -e 'puts "ok"' > $out
+                '';
+              };
+              mkRuby = {
+                nativeBuildInputs = [
+                  (self.lib.mkRuby {
+                    inherit pkgs rubyVersion;
+                  })
+                ];
+                command = ''
+                  ruby -e 'puts "ok"' > $out
+                '';
+              };
+            }
+            // (lib.optionalAttrs (with versionComparison rubyVersion; greaterOrEqualTo "2.4") {
+              # Ruby <2.4 only supports openssl 1.0 and not openssl1.1. openssl 1.0 is not supported by nixpkgs
+              # anymore, so we will not support it here.
+              openssl = {
+                nativeBuildInputs = [
+                  ruby
+                ];
+                command = ''
+                  ruby -e 'require "openssl"; puts OpenSSL::OPENSSL_VERSION' > $out
+                '';
+              };
+            })
+            // (lib.optionalAttrs (with versionComparison rubyVersion; greaterOrEqualTo "2.2") {
+              bundlerEnv =
+                let
+                  gems = pkgs.bundlerEnv {
+                    name = "gemset";
+                    inherit ruby;
+                    gemfile = ./tests/bundlerEnv/Gemfile;
+                    lockfile = ./tests/bundlerEnv/Gemfile.lock;
+                    gemset = ./tests/bundlerEnv/gemset.nix;
+                    groups = [
+                      "default"
+                      "production"
+                      "development"
+                      "test"
                     ];
-                    command = ''
-                      ruby -e 'require "foobar"; say' > $out
-                    '';
                   };
-              })
-            ) rubyPackages;
-
-            testAttrs = rubyTestAttrs // {
+                in
+                {
+                  nativeBuildInputs = [
+                    self.packages.${pkgs.system}.${rubyName}
+                    gems
+                  ];
+                  command = ''
+                    ruby -e 'require "foobar"; say' > $out
+                  '';
+                };
+            })
+          ) rubyPackages
+          // {
+            common = {
               packageFromRubyVersionFileWithoutEngine =
                 let
                   ruby = self.lib.packageFromRubyVersionFile {
@@ -284,16 +280,44 @@
                   '';
                 };
             };
+          };
+        mkCheckBatch =
+          groupName: batchAttrs:
+          let
+            batchChecks = lib.mapAttrs (
+              testName: attrs:
+              mkTest (
+                {
+                  name = flattenCheckName groupName testName;
+                }
+                // attrs
+              )
+            ) batchAttrs;
           in
-          lib.mapAttrs (
-            name: testAttrs:
-            mkTest (
-              {
-                inherit name;
-              }
-              // testAttrs
-            )
-          ) testAttrs;
+          batchChecks
+          // {
+            all = pkgs.linkFarm "${groupName}-checks" (
+              lib.mapAttrsToList (testName: checkDrv: {
+                name = testName;
+                path = checkDrv;
+              }) batchChecks
+            );
+          };
+        checkBatches = lib.mapAttrs mkCheckBatch checkBatchAttrs;
+        checks = lib.concatMapAttrs (
+          groupName: batchChecks:
+          lib.mapAttrs' (testName: checkDrv: {
+            name = flattenCheckName groupName testName;
+            value = checkDrv;
+          }) (lib.removeAttrs batchChecks [ "all" ])
+        ) checkBatches;
+      in
+      {
+        packages = intactPackages;
+
+        checkBatches = checkBatches;
+
+        checks = checks;
 
         formatter = pkgs.nixfmt-tree;
 
@@ -301,7 +325,7 @@
           # The shell for editing this project.
           default = pkgs.mkShell {
             nativeBuildInputs = with pkgs; [
-              nixfmt
+              nixfmt-tree
             ];
           };
         };
@@ -311,11 +335,7 @@
           program =
             let
               inherit (builtins)
-                map
-                attrNames
-                getFlake
                 concatStringsSep
-                filter
                 ;
               inherit (nixpkgs.lib) mapAttrsToList filterAttrs;
               pkgsetsToUpdate = filterAttrs (name: pkgset: pkgset ? updater) _pkgsets;


### PR DESCRIPTION
Currently CI sometimes needs to build _all_ ruby versions when a global change is made. This takes 6h+, which is over the GHA limit. The timed out build doesn't get pushed, so none of the internal builds of Ruby are being cached.

It would be nice if we could execute the build without hitting a GHA timeout. We can create a job per ruby version so that GHA will run many builds in parallel, each a normal amount of time and the 6h limit isn't hit.

I've split up the tests into 'groups'. Each ruby version is a group and there is an additional group for 'common' tests. The groups are being read in GHA and a matrix strategy, which is filled with all groups. Then all tests within each group is build within a separate job using the additional 'all' test, which is basically a linkFarm of the other tests in the group.