### PR TITLE
Set LANG for ruby 4.0.4+ support

### DIFF
--- a/ruby/package-fn.nix
+++ b/ruby/package-fn.nix
@@ -67,6 +67,12 @@ let
     # Have `configure' avoid `/usr/bin/nroff' in non-chroot builds.
     NROFF = if docSupport then "${groff}/bin/nroff" else null;
 
+    LANG =
+      if docSupport && (with versionComparison version; hasPrefix "4.0") then
+        "C.UTF-8"
+      else
+        null;
+
     nativeBuildInputs = [
       bison
     ] ++ ops (stdenv.buildPlatform != stdenv.hostPlatform) [ buildPackages.ruby ];


### PR DESCRIPTION
This is adapted from the ruby 4.0.4 bump in nixpkgs which also sets LANG[1] because some non-US-ASCII characters were added that RDoc fails to parse otherwise.

[1] https://github.com/NixOS/nixpkgs/pull/519212