### PR TITLE
renovate: enable lockFileMaintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,5 +12,8 @@
   "automerge": true,
   "schedule": [
     "every weekend"
-  ]
+  ],
+  "lockFileMaintenance": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
Renovate keeps failing to update flake.nix. There is an existing issue suggesting to make renovate delete+update flake.lock, so let's give that a try.

See https://github.com/renovatebot/renovate/discussions/35299