### PR TITLE
ruby: replace deprecated fetchFromSavannah

### DIFF
--- a/ruby/config.nix
+++ b/ruby/config.nix
@@ -1,8 +1,8 @@
 # Ruby >= 2.1.0 tries to download config.{guess,sub}
-{ fetchFromSavannah }:
+{ fetchgit }:
 
-fetchFromSavannah {
-  repo = "config";
+fetchgit {
+  url = "https://https.git.savannah.gnu.org/git/config.git";
   rev = "576c839acca0e082e536fd27568b90a446ce5b96";
   sha256 = "11bjngchjhj0qq0ppp8c37rfw0yhp230nvhs2jvlx15i9qbf56a0";
 }

--- a/ruby/package-fn.nix
+++ b/ruby/package-fn.nix
@@ -10,7 +10,7 @@
   lib,
   fetchurl,
   fetchpatch,
-  fetchFromSavannah,
+  fetchgit,
   fetchFromGitHub,
   zlib,
   openssl,
@@ -47,7 +47,7 @@ let
   op = lib.optional;
   ops = lib.optionals;
   opString = lib.optionalString;
-  config = import ./config.nix { inherit fetchFromSavannah; };
+  config = import ./config.nix { inherit fetchgit; };
 
   # Needed during postInstall
   buildRuby =


### PR DESCRIPTION
`fetchFromSavannah` is deprecated, so replace it with `fetchgit` for the GNU config source.

cgit snapshot tarballs can have unstable checksums and place unnecessary load on Savannah servers. Use Savannah's recommended distributed Git mirror with `fetchgit`, preserving the existing revision and hash.

- https://github.com/NixOS/nixpkgs/commit/03b2128fcc98eb9fefc3577fbb13b8636699d77b
- https://lists.gnu.org/archive/html/savannah-hackers/2025-12/msg00014.html

## Verification
- `nix eval --accept-flake-config --raw '.#packages.x86_64-linux."ruby-3.4.10".name'`
- `nix build --accept-flake-config --no-link '.#checkBatches.x86_64-linux."ruby-3.4.10".all'`